### PR TITLE
W2_S1_Tutorial reshape error

### DIFF
--- a/ML_EES/IP/W2_S1_Tutorial.ipynb
+++ b/ML_EES/IP/W2_S1_Tutorial.ipynb
@@ -644,7 +644,10 @@
     {
       "cell_type": "code",
       "source": [
-        "g = np.reshape(f, (8,9))"
+        "try:\n",
+        "    g = np.reshape(f, (8,9))\n",
+        "except ValueError:\n",
+        "    print(\"ValueError: cannot reshape array of size 5000 into shape (8,9)\")\n"
       ],
       "metadata": {
         "id": "EsXbyvFi5hI0"


### PR DESCRIPTION
except (catch) the error and only print message, to bypass the error so the notebook can be fully executed